### PR TITLE
Add gray streams support

### DIFF
--- a/bitio.asd
+++ b/bitio.asd
@@ -9,9 +9,17 @@
   :license "MIT License"
 
   :serial t
-  :depends-on (#:fast-io)
-  :components ((:file "package")
-           (:file "utils")
-           (:file "bitio")
-           (:file "bitio-read")
-           (:file "tests")))
+  :depends-on (#:fast-io
+               #:trivial-gray-streams
+               #:cl-package-locks
+               #:checkl)
+  :components ((:module "base"
+                        :pathname ""
+                        :components ((:file "package")
+                                     (:file "utils")
+                                     (:file "bitio")
+                                     (:file "bitio-read")
+                                     (:file "tests")))
+               (:module "contrib"
+                        :components ((:file "gray")
+                                     (:file "gray-test")))))

--- a/bitio.lisp
+++ b/bitio.lisp
@@ -34,13 +34,13 @@
                          :reader %bitio/read-sequence)
    (%default-bit-endian :initarg :default-bit-endian
                         :initform :be
-                        :reader default-bit-endian)
+                        :accessor default-bit-endian)
    (%default-byte-endian :initarg :default-byte-endian
                          :initform :le
-                         :reader default-byte-endian)
+                         :accessor default-byte-endian)
    (%default-bits-per-byte :initarg :default-bits-per-byte
                            :initform 8
-                           :reader default-bits-per-byte)))
+                           :accessor default-bits-per-byte)))
 
 (defgeneric bitio/read-octet (bitio &optional eof-error-p eof-value)
   (:documentation "Read an octet from the funciton supplied with the stream

--- a/contrib/gray-test.lisp
+++ b/contrib/gray-test.lisp
@@ -1,0 +1,30 @@
+;;;; bitio/contrib/gray-test.lisp
+
+(in-package :bitio.gray)
+
+(check (:name :bitio.gray)
+  (nest
+   (let ((element-type '(unsigned-byte 8))))
+   (with-temporary-file (:stream octet-stream :direction :io :element-type element-type)
+     (write-sequence (octets-from '(1 2 3 4)) octet-stream)
+     (file-position octet-stream 0))
+   (let* ((bs (make-bitio-stream octet-stream #'read-byte #'read-sequence
+                                 :byte-endian :be :bit-endian :be :bits-per-byte 8)))
+     (results
+      (read-byte bs)
+      (read-byte bs)
+      (read-byte bs)
+      (read-byte bs)
+      (file-position bs)
+      (stream-element-type bs)
+      (file-position bs 0)
+      (file-position bs)
+      (setf (stream-element-type bs) '(unsigned-byte 16))
+      (stream-element-type bs)
+      (read-byte bs)
+      (read-byte bs)
+      (file-position bs)
+      (file-position bs 0)
+      (let ((seq (make-octet-vector 4)))
+        (setf (stream-element-type bs) '(unsigned-byte 8))
+        (values seq (read-sequence seq bs)))))))

--- a/contrib/gray.lisp
+++ b/contrib/gray.lisp
@@ -7,11 +7,6 @@
 
 (defclass bitio-input-stream (bitio-stream fundamental-input-stream) ())
 
-;; (defmethod ms:class-persistent-slots ((self bitio-input-stream))
-;;   '(bitio::%default-bits-per-byte bitio::%read-bit-stable
-;;     bitio::%bitio/read-octet bitio::%bitio/read-sequence bitio::%default-bit-endian
-;;     bitio::%default-byte-endian bitio::%default-bits-per-byte))
-
 (defun make-bitio-stream (octet-stream bitio/read-octet bitio/read-sequence
                           &key (bit-endian :be) (byte-endian :le) (bits-per-byte 8)
                             (octet-read-buffer-size 4096))

--- a/contrib/gray.lisp
+++ b/contrib/gray.lisp
@@ -1,0 +1,92 @@
+;;;; bitio/gray.lisp
+
+(in-package :bitio.gray)
+
+(defclass bitio-stream (bitio fundamental-binary-stream)
+  ())
+
+(defclass bitio-input-stream (bitio-stream fundamental-input-stream) ())
+
+;; (defmethod ms:class-persistent-slots ((self bitio-input-stream))
+;;   '(bitio::%default-bits-per-byte bitio::%read-bit-stable
+;;     bitio::%bitio/read-octet bitio::%bitio/read-sequence bitio::%default-bit-endian
+;;     bitio::%default-byte-endian bitio::%default-bits-per-byte))
+
+(defun make-bitio-stream (octet-stream bitio/read-octet bitio/read-sequence
+                          &key (bit-endian :be) (byte-endian :le) (bits-per-byte 8)
+                            (octet-read-buffer-size 4096))
+  (let ((stream (make-bitio octet-stream bitio/read-octet bitio/read-sequence
+                            :bit-endian bit-endian :byte-endian byte-endian :bits-per-byte bits-per-byte
+                            :octet-read-buffer-size octet-read-buffer-size)))
+    (change-class stream 'bitio-input-stream)
+    stream))
+
+(defmethod stream-byte-endian (stream)
+  (slot-value stream 'bitio::%default-byte-endian))
+(defmethod stream-bit-endian (stream)
+  (slot-value stream 'bitio::%default-bit-endian))
+
+(defmethod (setf stream-byte-endian) (new-val (stream bitio-stream))
+  (setf (slot-value stream 'bitio::%default-byte-endian) new-val))
+(defmethod (setf stream-bit-endian) (new-val (stream bitio-stream))
+  (setf (slot-value stream 'bitio::%default-bit-endian) new-val))
+
+(defmethod input-stream-p ((stream bitio-stream))
+  (typep stream 'bitio-input-stream))
+
+(defmethod stream-file-position ((stream bitio-stream))
+  "stream must implement:
+   `stream-file-position, stream-element-type (also setf!)'"
+  (nest
+   (with-accessors ((octet-stream bitio::octet-stream)
+                    (num-bits-in-stable bitio::num-bits-in-stable)
+                    (byte-size bitio::default-bits-per-byte)) stream)
+   (multiple-value-bind (normalized-fp rest)
+       (floor (+ num-bits-in-stable (* (file-position octet-stream)
+                                       (second (stream-element-type octet-stream))))
+              byte-size)
+     (values normalized-fp rest))))
+
+(defmethod (setf stream-file-position) (position-spec (stream bitio-input-stream))
+  (nest
+   (with-accessors ((bit-endian bitio::default-bit-endian)
+                    (byte-endian bitio::default-byte-endian)
+                    (num-bits-in-stable bitio::num-bits-in-stable)
+                    (read-bit-stable bitio::read-bit-stable)
+                    (bits-per-byte bitio::default-bits-per-byte)
+                    (octet-stream bitio::octet-stream)) stream)
+   (let ((bit-position (* position-spec bits-per-byte))))
+   (multiple-value-bind (octet-position rest) (floor bit-position 8)
+     (file-position octet-stream octet-position)
+     (setf read-bit-stable 0)
+     (setf num-bits-in-stable 0)
+     (read-bits stream rest)
+     position-spec)))
+
+(defmethod stream-read-byte ((stream bitio-input-stream))
+  (read-one-byte stream))
+
+(defmethod stream-read-sequence ((stream bitio-stream) sequence start end
+                                 &key bit-endian bits-per-byte &allow-other-keys)
+  (with-accessors ((default-bit-endian bitio::default-bit-endian)
+                   (default-bits-per-byte bitio::default-bits-per-byte))
+      stream
+    (read-bytes stream sequence
+                :start start
+                :end end
+                :bit-endian (or bit-endian default-bit-endian)
+                :bits-per-byte (or bits-per-byte default-bits-per-byte))))
+
+(defmethod stream-element-type ((stream bitio-stream))
+  (values `(unsigned-byte ,(bitio::default-bits-per-byte stream))
+          `(:byte-endian ,(bitio::default-byte-endian stream))
+          `(:bit-endian ,(bitio::default-bit-endian stream))))
+
+(with-packages-unlocked (cl)
+  (defmethod (setf stream-element-type) (new-val (stream bitio-stream))
+    (with-accessors ((byte-size bitio::default-bits-per-byte)) stream
+      (assert (eq 'unsigned-byte (car new-val)))
+      (setf byte-size (second new-val)))))
+
+(defmethod peek-byte ((stream bitio-input-stream) &optional peek-type eof-error-p eof-value)
+  (error "Not implemented for this class: ~s" (class-name (class-of stream))))

--- a/package.lisp
+++ b/package.lisp
@@ -12,4 +12,16 @@
            #:read-integer
            #:octet-read-boundary-p))
 
+(uiop:define-package #:bitio.gray
+    (:use #:cl #:bitio #:fast-io)
+  (:mix #:uiop
+        #:trivial-gray-streams
+        #:cl-package-locks
+        #:checkl)
+  (:export :make-bitio-stream
+           :input-stream-p
+           :peek-byte
+           :stream-bit-endian
+           :stream-byte-endian))
+
 (in-package #:bitio)


### PR DESCRIPTION
Hi, firstly very nice to find this library. I was working on something similar but figured I would use this library and contribute what I might need for something I am working on.

I have implemented the gray streams interface for bitio input streams. This will make it easier to use these streams in older libraries depending on the gray streams interface and also provides a known interface for others using this library.

What I have also done which I have not seen implemented before but I have been missing for common lisp streams is to implement setfable element-type. Seeing that bitio streams can read any type of element it made sense to make it changeable. Changing byte reads can be very handy. The common-lisp package puts a lock on this method so I had to temporary unlock the :cl package.

I have not written any documentation yet. Or docstrings for that matter. I would consider it if you want to include this PR. I also use :checkl as a testing framework. Hope it is ok to add it as a dependency.

cheers!